### PR TITLE
Fix API error 403 Incompatible JSON when including attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+django_postmark.egg-info

--- a/postmark/__init__.py
+++ b/postmark/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 1, 7, "dev", 1)
+VERSION = (0, 1, 7, "dev", 2)
 
 
 def get_version():

--- a/postmark/__init__.py
+++ b/postmark/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 1, 6, "final", 0)
+VERSION = (0, 1, 6, "final", 1)
 
 
 def get_version():

--- a/postmark/__init__.py
+++ b/postmark/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 1, 6, "final", 1)
+VERSION = (0, 1, 7, "dev", 1)
 
 
 def get_version():

--- a/postmark/backends.py
+++ b/postmark/backends.py
@@ -3,6 +3,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.core.exceptions import ImproperlyConfigured
 from django.core import serializers
 from django.conf import settings
+import base64
 import httplib2
 
 try:
@@ -120,7 +121,11 @@ class PostmarkMessage(dict):
             
             if message.attachments and isinstance(message.attachments, list):
                 if len(message.attachments):
-                    message_dict["Attachments"] = message.attachments
+                    message_dict["Attachments"] = [{
+                        'Name': n,
+                        'Content': base64.encodestring(c).strip(),
+                        'ContentType': ct,
+                    } for n, c, ct in message.attachments]
             
         except:
             if fail_silently:

--- a/postmark/models.py
+++ b/postmark/models.py
@@ -5,12 +5,10 @@ from itertools import izip_longest
 from datetime import datetime
 from pytz import timezone
 import pytz
-from django.conf import settings
 
 from postmark.signals import post_send
 
 POSTMARK_DATETIME_STRING = "%Y-%m-%dT%H:%M:%S.%f"
-POSTMARK_USE_TZ = getattr(settings, "POSTMARK_USE_TZ", True)
 
 TO_CHOICES = (
     ("to", _("Recipient")),
@@ -103,14 +101,12 @@ def sent_message(sender, **kwargs):
         
         if not recipient[0]:
             continue
-
+        
         timestamp, tz = resp["SubmittedAt"].rsplit("+", 1)
         tz_offset = int(tz.split(":", 1)[0])
         tz = timezone("Etc/GMT%s%d" % ("+" if tz_offset >= 0 else "-", tz_offset))
         submitted_at = tz.localize(datetime.strptime(timestamp[:26], POSTMARK_DATETIME_STRING)).astimezone(pytz.utc)
-
-        if POSTMARK_USE_TZ == False:
-            submitted_at = submitted_at.replace(tzinfo=None)
+        
         
         emsg = EmailMessage(
             message_id=resp["MessageID"],

--- a/postmark/models.py
+++ b/postmark/models.py
@@ -2,9 +2,9 @@ from django.utils.translation import ugettext_lazy as _
 from django.dispatch import receiver
 from django.db import models
 from itertools import izip_longest
-from datetime import datetime
-from pytz import timezone
 import pytz
+import dateutil.parser
+from django.conf import settings
 
 from postmark.signals import post_send
 
@@ -101,12 +101,11 @@ def sent_message(sender, **kwargs):
         
         if not recipient[0]:
             continue
-        
-        timestamp, tz = resp["SubmittedAt"].rsplit("+", 1)
-        tz_offset = int(tz.split(":", 1)[0])
-        tz = timezone("Etc/GMT%s%d" % ("+" if tz_offset >= 0 else "-", tz_offset))
-        submitted_at = tz.localize(datetime.strptime(timestamp[:26], POSTMARK_DATETIME_STRING)).astimezone(pytz.utc)
-        
+
+        submitted_at = dateutil.parser.parse(resp["SubmittedAt"]).astimezone(pytz.utc)
+
+        if POSTMARK_USE_TZ == False:
+            submitted_at = submitted_at.replace(tzinfo=None)
         
         emsg = EmailMessage(
             message_id=resp["MessageID"],

--- a/postmark/models.py
+++ b/postmark/models.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from postmark.signals import post_send
 
 POSTMARK_DATETIME_STRING = "%Y-%m-%dT%H:%M:%S.%f"
+POSTMARK_USE_TZ = getattr(settings, "POSTMARK_USE_TZ", True)
 
 TO_CHOICES = (
     ("to", _("Recipient")),

--- a/postmark/views.py
+++ b/postmark/views.py
@@ -2,7 +2,6 @@ from django.http import HttpResponse, HttpResponseNotAllowed, HttpResponseBadReq
 from django.core.exceptions import ImproperlyConfigured
 from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import get_object_or_404
-from django.conf import settings
 import pytz
 import base64
 import dateutil.parser
@@ -75,7 +74,7 @@ def bounce(request):
         bounced_at = dateutil.parser.parse(bounce_dict["BouncedAt"]).astimezone(pytz.utc)
             
         if POSTMARK_USE_TZ == False:
-            submitted_at = submitted_at.replace(tzinfo=None)
+            bounced_at = bounced_at.replace(tzinfo=None)
 
         em = get_object_or_404(EmailMessage, message_id=bounce_dict["MessageID"], to=bounce_dict["Email"])
         eb, created = EmailBounce.objects.get_or_create(

--- a/postmark/views.py
+++ b/postmark/views.py
@@ -3,10 +3,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import get_object_or_404
 from django.conf import settings
-from datetime import datetime
-from pytz import timezone
 import pytz
 import base64
+import dateutil.parser
 from django.conf import settings
 
 from postmark.models import EmailMessage, EmailBounce
@@ -73,10 +72,7 @@ def bounce(request):
         
         bounce_dict = json.loads(request.read())
             
-        timestamp, tz = bounce_dict["BouncedAt"].rsplit("+", 1)
-        tz_offset = int(tz.split(":", 1)[0])
-        tz = timezone("Etc/GMT%s%d" % ("+" if tz_offset >= 0 else "-", tz_offset))
-        bounced_at = tz.localize(datetime.strptime(timestamp[:26], POSTMARK_DATETIME_STRING)).astimezone(pytz.utc)
+        bounced_at = dateutil.parser.parse(bounce_dict["BouncedAt"]).astimezone(pytz.utc)
             
         if POSTMARK_USE_TZ == False:
             submitted_at = submitted_at.replace(tzinfo=None)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     install_requires = [
         "httplib2",
         "pytz",
+        "python-dateutil",
     ],
     packages = [
         "postmark",


### PR DESCRIPTION
The API expects that the attachments will be a list of dictionaries
rather than a list of tuples. In addition, the content must be a base64
encoded string.
