### PR TITLE
Fixed attachment deserialisation

### DIFF
--- a/postmark/backends.py
+++ b/postmark/backends.py
@@ -120,7 +120,7 @@ class PostmarkMessage(dict):
             
             if message.attachments and isinstance(message.attachments, list):
                 if len(message.attachments):
-                    message_dict["Attachments"] = message.attachments
+                    message_dict["Attachments"] =[{"Name": x[0], "Content": x[1], "ContentType":x[2]} for x in message.attachments]
             
         except:
             if fail_silently:


### PR DESCRIPTION
Using the old version with attachments would result in a 403 error
(Incompatible JSON) due to the wrong json deserialisation
